### PR TITLE
Compensate for exposure after sampling background color, adjust transmission example 

### DIFF
--- a/crates/bevy_pbr/src/render/pbr_transmission.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_transmission.wgsl
@@ -42,6 +42,9 @@ fn specular_transmissive_light(world_position: vec4<f32>, frag_coord: vec3<f32>,
         background_color = fetch_transmissive_background(offset_position, frag_coord, view_z, perceptual_roughness);
     }
 
+    // Compensate for exposure, since the background color is coming from an already exposure-adjusted texture
+    background_color = vec4(background_color.rgb / view_bindings::view.exposure, background_color.a);
+
     // Dot product of the refracted direction with the exit normal (Note: We assume the exit normal is the entry normal but inverted)
     let MinusNdotT = dot(-N, T);
 

--- a/examples/3d/transmission.rs
+++ b/examples/3d/transmission.rs
@@ -156,7 +156,7 @@ fn setup(
         PbrBundle {
             mesh: icosphere_mesh.clone(),
             material: materials.add(StandardMaterial {
-                emissive: Color::ANTIQUE_WHITE * 20.0 + Color::ORANGE_RED * 4.0,
+                emissive: Color::ANTIQUE_WHITE * 80.0 + Color::ORANGE_RED * 16.0,
                 diffuse_transmission: 1.0,
                 ..default()
             }),

--- a/examples/3d/transmission.rs
+++ b/examples/3d/transmission.rs
@@ -328,7 +328,7 @@ fn setup(
             transform: Transform::from_xyz(-1.0, 1.7, 0.0),
             point_light: PointLight {
                 color: Color::ANTIQUE_WHITE * 0.8 + Color::ORANGE_RED * 0.2,
-                intensity: 1600.0,
+                intensity: 240_000.0,
                 radius: 0.2,
                 range: 5.0,
                 shadows_enabled: true,
@@ -358,6 +358,7 @@ fn setup(
         #[cfg(not(all(feature = "webgl2", target_arch = "wasm32")))]
         TemporalAntiAliasBundle::default(),
         EnvironmentMapLight {
+            intensity: 100.0,
             diffuse_map: asset_server.load("environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),
             specular_map: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
         },
@@ -651,7 +652,7 @@ fn flicker_system(
     let c = (s * 7.0).cos() * 0.0125 + (s * 2.0).cos() * 0.025;
     let (mut light, mut light_transform) = light.single_mut();
     let mut flame_transform = flame.single_mut();
-    light.intensity = 1600.0 + 3000.0 * (a + b + c);
+    light.intensity = 240_000.0 + 3000.0 * (a + b + c);
     flame_transform.translation = Vec3::new(-1.0, 1.23, 0.0);
     flame_transform.look_at(Vec3::new(-1.0 - c, 1.7 - b, 0.0 - a), Vec3::X);
     flame_transform.rotate(Quat::from_euler(EulerRot::XYZ, 0.0, 0.0, PI / 2.0));

--- a/examples/3d/transmission.rs
+++ b/examples/3d/transmission.rs
@@ -328,7 +328,7 @@ fn setup(
             transform: Transform::from_xyz(-1.0, 1.7, 0.0),
             point_light: PointLight {
                 color: Color::ANTIQUE_WHITE * 0.8 + Color::ORANGE_RED * 0.2,
-                intensity: 240_000.0,
+                intensity: 60_000.0,
                 radius: 0.2,
                 range: 5.0,
                 shadows_enabled: true,
@@ -348,7 +348,6 @@ fn setup(
             },
             transform: Transform::from_xyz(1.0, 1.8, 7.0).looking_at(Vec3::ZERO, Vec3::Y),
             color_grading: ColorGrading {
-                exposure: -2.0,
                 post_saturation: 1.2,
                 ..default()
             },
@@ -358,7 +357,7 @@ fn setup(
         #[cfg(not(all(feature = "webgl2", target_arch = "wasm32")))]
         TemporalAntiAliasBundle::default(),
         EnvironmentMapLight {
-            intensity: 100.0,
+            intensity: 25.0,
             diffuse_map: asset_server.load("environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),
             specular_map: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
         },
@@ -652,7 +651,7 @@ fn flicker_system(
     let c = (s * 7.0).cos() * 0.0125 + (s * 2.0).cos() * 0.025;
     let (mut light, mut light_transform) = light.single_mut();
     let mut flame_transform = flame.single_mut();
-    light.intensity = 240_000.0 + 3000.0 * (a + b + c);
+    light.intensity = 60_000.0 + 3000.0 * (a + b + c);
     flame_transform.translation = Vec3::new(-1.0, 1.23, 0.0);
     flame_transform.look_at(Vec3::new(-1.0 - c, 1.7 - b, 0.0 - a), Vec3::X);
     flame_transform.rotate(Quat::from_euler(EulerRot::XYZ, 0.0, 0.0, PI / 2.0));


### PR DESCRIPTION
This PR fixes the underexposed transmitted images.

Turns out since exposure is now applied to transmitted light (like all other light types), and the transmitted light was being sampled from an already exposure adjusted background image, we were effectively applying exposure _twice_. We now compensate for that.

This PR also tweaks the example to look good under the new default exposure settings, and removes the `ColorGrading` exposure adjustment, now that `EnviromentMapLight`s can have their intensity adjusted. (It was a workaround for an overly bright enviroment map)

<img width="1392" alt="image" src="https://github.com/GitGhillie/bevy/assets/418473/d7efa0cf-c0f2-4523-b99e-0e6ea4765932">
